### PR TITLE
only use first 44 columns of tcplFit result otherwise there is an err…

### DIFF
--- a/R/toxboot.R
+++ b/R/toxboot.R
@@ -132,7 +132,7 @@ toxboot <- function(dat,
                   logc = logc_vect,
                   bmad = datchemval$bmad[1])
 
-  datchemresult <- as.data.table(t(temp2))
+  datchemresult <- as.data.table(t(temp2))[,1:44]
   setnames(datchemresult, fitpars)
   datchemresult <- sapply(datchemresult, as.numeric)
   datchemresult <- as.data.table(datchemresult)


### PR DESCRIPTION
…or because fitpars only has 44 column names.  This is due to new version of tcpl.